### PR TITLE
Fix createSlice for reference type

### DIFF
--- a/sszgen/generator/unmarshal.go
+++ b/sszgen/generator/unmarshal.go
@@ -340,7 +340,7 @@ func (v *Value) createSlice(useNumVariable bool) string {
 		// []int uses the Extend functions in the fastssz package
 		return fmt.Sprintf("::.%s = ssz.Extend%s(::.%s, %s)", v.name, uintVToName(v.e), v.name, size)
 
-	case TypeContainer:
+	case TypeContainer, TypeReference:
 		// []*(ref.)Struct{}
 		ptr := "*"
 		if v.e.noPtr {


### PR DESCRIPTION
The problem was found when trying to serialize field `v []Uint256`, where Uint256 is a struct with SSZ interface.